### PR TITLE
Add single-post conversion tool

### DIFF
--- a/docs/blog_arch_usage.md
+++ b/docs/blog_arch_usage.md
@@ -1,0 +1,45 @@
+# Blog Archiver Usage
+
+`blog_arch.py` downloads Blogspot posts within a time range and rewrites
+links so the pages work completely offline. Posts, images, and stylesheets
+are saved inside an output directory.
+
+## Requirements
+
+- Python 3
+- The [`requests`](https://pypi.org/project/requests/) package
+
+Install `requests` with `pip install requests` if it is not already available.
+
+## Command line
+
+```bash
+python3 utils/blog_arch.py -b BLOG_URL START END [-o OUTPUT]
+```
+
+Arguments:
+
+- `-b`/`--blog-url` – Base URL of the Blogspot site (e.g.
+  `https://example.blogspot.com`).
+- `START` – ISO 8601 UTC timestamp for the beginning of the range, such as
+  `2020-01-01T00:00:00Z`.
+- `END` – ISO 8601 UTC timestamp for the end of the range.
+- `-o`/`--out` – Directory to write the archives (default: `./archive`).
+
+Each post is stored in a timestamped folder under the output directory.
+`index.html` contains the page content with CSS and images referenced locally.
+
+## Example
+
+To archive posts from September 6 2015 through September 8 2016 from
+<https://copaseticflow.blogspot.com> into `./archive`:
+
+```bash
+python3 utils/blog_arch.py \
+    -b https://copaseticflow.blogspot.com \
+    2015-09-06T00:00:00Z 2016-09-08T00:00:00Z \
+    -o archive
+```
+
+During processing the script prints the downloaded CSS and images. If an
+image URL returns an error, a warning is displayed but the archive continues.

--- a/utils/convert_post.py
+++ b/utils/convert_post.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Download a single Blogspot post and convert to Tufte CSS HTML."""
+
+import os
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from utils.blog_arch import download_file, USER_AGENT
+
+
+def convert_post(url: str, out_dir: str = "output") -> str:
+    """Download *url* and save converted HTML under *out_dir*.
+
+    Returns the path to the generated HTML file.
+    """
+    r = requests.get(url, headers={"User-Agent": USER_AGENT})
+    r.raise_for_status()
+
+    soup = BeautifulSoup(r.text, "html.parser")
+    body = soup.find("div", class_="post-body-container")
+    if body is None:
+        raise RuntimeError("post-body-container div not found")
+
+    os.makedirs(out_dir, exist_ok=True)
+    img_dir = os.path.join(out_dir, "img")
+    os.makedirs(img_dir, exist_ok=True)
+
+    # Download images referenced in the body
+    for img in body.find_all("img"):
+        src = img.get("src")
+        if not src or src.startswith("data:"):
+            continue
+        full = urljoin(url, src)
+        name = os.path.basename(urlparse(full).path)
+        if not name:
+            continue
+        dest = os.path.join(img_dir, name)
+        try:
+            download_file(full, dest)
+            img["src"] = f"img/{name}"
+            print(f"  ↳ downloaded {name}")
+        except Exception as e:
+            print(f"    ❌ {full}: {e}")
+
+    html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <link rel=\"stylesheet\" href=\"https://cootermaroos.com/tufte.css\" />
+  <title>{soup.title.string if soup.title else ''}</title>
+</head>
+<body>
+<article>
+{body}
+</article>
+</body>
+</html>
+"""
+
+    filename = os.path.basename(urlparse(url).path) or "index.html"
+    out_path = os.path.join(out_dir, filename)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    print(f"Saved HTML to {out_path}")
+    return out_path
+
+
+def main():
+    import argparse
+
+    p = argparse.ArgumentParser(description="Convert a single Blogspot post")
+    p.add_argument("url", help="URL of the blog post")
+    p.add_argument("-o", "--out", default="output", help="Output directory")
+    args = p.parse_args()
+
+    convert_post(args.url, args.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `utils/convert_post.py` to download a single Blogspot post into Tufte CSS format
- add empty `utils/__init__.py`

## Testing
- `python3 -m utils.convert_post https://copaseticflow.blogspot.com/2016/09/of-babies-and-bombs.html -o sample`


------
https://chatgpt.com/codex/tasks/task_e_6876bfc353f48321b321ec174d501916